### PR TITLE
Use the popular 'fullname' template definition.

### DIFF
--- a/bitnami/etcd/templates/_helpers.tpl
+++ b/bitnami/etcd/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "etcd.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
The template definition for 'fullname' usually incorporates the ability to not prepend the release name by using the chart name in the release name. This is useful for spinning up multiple charts with default service names, avoiding the need to spread knowledge of release names for simple deployment scenarios.